### PR TITLE
Added a delay for "press to speak" when a user leaves the button

### DIFF
--- a/voice/voice-ai/x/Actions/ActionsView.swift
+++ b/voice/voice-ai/x/Actions/ActionsView.swift
@@ -242,7 +242,10 @@ struct ActionsView: View {
                         }
                         .onEnded { _ in
                             self.isSpeakButtonPressed = false
-                            actionHandler.handle(actionType: ActionType.stopSpeak)
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                                actionHandler.handle(actionType: ActionType.stopSpeak)
+                            }
+                            
                         }
                 )
             }


### PR DESCRIPTION
issue: When Press to Speak is too quick, it doesn't detect voice.