### PR TITLE
Removing custom instructions from saved transcript

### DIFF
--- a/voice/voice-ai/x/AppSettings/SettingsView.swift
+++ b/voice/voice-ai/x/AppSettings/SettingsView.swift
@@ -122,8 +122,11 @@ struct SettingsView: View {
         for message in messages {
             let label = message.role?.lowercased() == "user" ? "User:" : "GPT:"
             if let content = message.content {
-                transcript += "\(label) \(content)\n"
-            }
+                        if label == "GPT:" && content == "We are having a face-to-face voice conversation. Be concise, direct and certain. Avoid apologies, interjections, disclaimers, pleasantries, confirmations, remarks, suggestions, chitchats, thankfulness, acknowledgements. Never end with questions. Never mention your being AI or knowledge cutoff. Your name is Sam." {
+                            continue
+                        }
+                        transcript += "\(label) \(content)\n"
+                    }
         }
 
         return transcript


### PR DESCRIPTION
Remove the custom instruction that we pass in as part of the saved transcript.